### PR TITLE
fix s2_dot formatting for justification

### DIFF
--- a/src/s2_dot.erl
+++ b/src/s2_dot.erl
@@ -43,7 +43,7 @@ gen_vertices(Vertices) ->
   lists:flatmap(fun gen_vertex/1, Vertices).
 
 gen_vertex({Vertex, Label}) ->
-  io_lib:format("~s [label=~p];~n", [Vertex, Label]).
+  io_lib:format("~s [label=\"~s\"];~n", [Vertex, Label]).
 
 gen_edges(Edges) ->
   lists:flatmap(fun gen_edge/1, Edges).


### PR DESCRIPTION
I wanted to be able to make a label that includes \n,\l and \r which means a centered line, a left justified and right justified lines. Pretty printing would insist in escaping backslashes.

It allows me to do multi-line labels that look better:

![new_payable_content dot](https://user-images.githubusercontent.com/52162652/67389099-338a9680-f59a-11e9-9bae-ef8daba3301c.png)
