### PR TITLE
feat: Support mapping over maybes; add functor type class

### DIFF
--- a/include/prelude.hrl
+++ b/include/prelude.hrl
@@ -455,6 +455,7 @@
 -type alist(A, B) :: [{A, B}].
 -type fd()        :: file:io_device().
 -type file()      :: string().
+-type functor(A)  :: s2_functors:functor(A).
 -type thunk(A)    :: fun(() -> A).
 
 -type ok(A)       :: {ok, A}.

--- a/include/prelude.hrl
+++ b/include/prelude.hrl
@@ -57,6 +57,9 @@
 -define(do(F0, F1, F2, F3, F4, F5, F6, F7, F8, F9),
         s2_maybe:do([F0, F1, F2, F3, F4, F5, F6, F7, F8, F9])).
 
+-define(fmap(F, Functor),
+        s2_functors:fmap(F, Functor)).
+
 -define(ido(F0, F1),
         ?ido([F0, F1])).
 -define(ido(F0, F1, F2),

--- a/src/s2_functors.erl
+++ b/src/s2_functors.erl
@@ -1,0 +1,70 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% @doc The Functor Type Class.
+%%% @end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%_* Module declaration ===============================================
+-module(s2_functors).
+
+%%%_* Exports ==========================================================
+-export([fmap/2]).
+
+%%%_* Includes =========================================================
+-include("prelude.hrl").
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+%%%_* Types ============================================================
+-type functor(A) :: maybe(A, _)   |
+                    [A]           |
+                    #{_ := A}     |
+                    fun((_) -> A) |
+                    {A}.
+
+%%%_* Code =============================================================
+-spec fmap(fun((A) -> B), functor(A)) -> functor(B).
+%%@doc fmap(F, Functor) is the result of calling F on every value in Functor.
+fmap(F, {ok, _} = Maybe)    when is_function(F, 1)                      -> s2_maybe:fmap(F, Maybe);
+fmap(F, {error, _} = Maybe) when is_function(F, 1)                      -> s2_maybe:fmap(F, Maybe);
+fmap(F, List)               when is_function(F, 1), is_list(List)       -> lists:map(F, List);
+fmap(F, Map)                when is_function(F, 1), is_map(Map)         -> maps:map(fun(_K, V) -> F(V) end, Map);
+fmap(F, Fun)                when is_function(F, 1), is_function(Fun, 1) -> s2_funs:o(F, Fun);
+fmap(F, Tuple)              when is_function(F, 1), is_tuple(Tuple)     -> list_to_tuple(fmap(F, tuple_to_list(Tuple))).
+
+-ifdef(TEST).
+
+%%%_* Tests ============================================================
+%% Add functors to this list to make sure that they satify the functor
+%% laws. The laws should hold true for any `Value`.
+functors(Value) ->
+  [ {ok, Value}
+  , [Value]
+  , #{key => Value}
+  , fun(arg) -> Value end
+  , {Value}].
+
+assertEqual(Expected, Actual) when is_function(Expected), is_function(Actual) ->
+  assertEqual(Expected(arg), Actual(arg));
+assertEqual(Expected, Actual) ->
+  ?assertEqual(Expected, Actual).
+
+preserve_identity_morphism_test() ->
+  CheckLaw = fun(Functor) -> assertEqual(Functor, fmap(fun s2_funs:id/1, Functor)) end,
+  lists:foreach(CheckLaw, functors({ok, 2})).
+
+preserve_composition_of_morphisms_test() ->
+  F        = fun({ok, Value}) -> {ok, Value - 1}                              end,
+  G        = fun({ok, Value}) -> {ok, Value * 2}                              end,
+  Composed = fun(Functor) -> fmap(s2_funs:o(F, G), Functor)                   end,
+  Chained  = fun(Functor) -> fmap(F, fmap(G, Functor))                        end,
+  CheckLaw = fun(Functor) -> assertEqual(Chained(Functor), Composed(Functor)) end,
+  lists:foreach(CheckLaw, functors({ok, 2})).
+
+-endif.
+
+%%%_* Emacs ============================================================
+%%% Local Variables:
+%%% allout-layout: t
+%%% erlang-indent-level: 2
+%%% End:

--- a/src/s2_functors.erl
+++ b/src/s2_functors.erl
@@ -1,58 +1,75 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% @doc The Functor Type Class.
+%%% The Functor type class represents types that can be mapped over. Type
+%%% constructors can become part of the Functor type class by providing an
+%%% implementation of the `fmap` function. See here for more details:
+%%% https://wiki.haskell.org/Functor
 %%% @end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-%%%_* Module declaration ===============================================
+%%%_* Module declaration ======================================================
 -module(s2_functors).
 
-%%%_* Exports ==========================================================
+%%%_* Macros ==================================================================
+-define(is_F(F), is_function(F, 1)).
+
+%%%_* Exports =================================================================
 -export([fmap/2]).
+-export_type([functor/1]).
 
-%%%_* Includes =========================================================
--include("prelude.hrl").
--ifdef(TEST).
--include_lib("eunit/include/eunit.hrl").
--endif.
+%%%_* Types ===================================================================
+%% The following type constructors are instances of the `functor` type class.
+%% Note that types must be without overlap for any arbitrary value of `A`.
+%%
+%% As a result, we have to choose between making either `list` or `dict` an
+%% instance of functor. That's because a dict `[{ok, 2}, {error, 3}]` is
+%% indiscernable from a list of `maybe(integer(), integer())`.
+%%
+%% Similarly, we have to choose between making `tuple` an instance of functor,
+%% or implementing different clauses of `fmap` for tuple-based types such as
+%% `maybe`.
+-type functor(A) :: [A]
+                    | #{_ := A}
+                    | fun((_) -> A)
+                    | s2_maybe:maybe(A, _).
 
-%%%_* Types ============================================================
--type functor(A) :: maybe(A, _)   |
-                    [A]           |
-                    #{_ := A}     |
-                    fun((_) -> A) |
-                    {A}.
-
-%%%_* Code =============================================================
+%%%_* Code ====================================================================
 -spec fmap(fun((A) -> B), functor(A)) -> functor(B).
 %%@doc fmap(F, Functor) is the result of calling F on every value in Functor.
-fmap(F, {ok, _} = Maybe)    when is_function(F, 1)                      -> s2_maybe:fmap(F, Maybe);
-fmap(F, {error, _} = Maybe) when is_function(F, 1)                      -> s2_maybe:fmap(F, Maybe);
-fmap(F, List)               when is_function(F, 1), is_list(List)       -> lists:map(F, List);
-fmap(F, Map)                when is_function(F, 1), is_map(Map)         -> maps:map(fun(_K, V) -> F(V) end, Map);
-fmap(F, Fun)                when is_function(F, 1), is_function(Fun, 1) -> s2_funs:o(F, Fun);
-fmap(F, Tuple)              when is_function(F, 1), is_tuple(Tuple)     -> list_to_tuple(fmap(F, tuple_to_list(Tuple))).
+fmap(F, List)               when ?is_F(F), is_list(List) -> lists:map(F, List);
+fmap(F, Map)                when ?is_F(F), is_map(Map)   -> maps:map(fun(_, V) -> F(V) end, Map);
+fmap(F, Fun)                when ?is_F(F), ?is_F(Fun)    -> s2_funs:o(F, Fun);
+fmap(F, {ok, _} = Maybe)    when ?is_F(F)                -> s2_maybe:fmap(F, Maybe);
+fmap(F, {error, _} = Maybe) when ?is_F(F)                -> s2_maybe:fmap(F, Maybe).
 
+%%%_* Tests ===================================================================
 -ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
 
-%%%_* Tests ============================================================
-%% Add functors to this list to make sure that they satify the functor
-%% laws. The laws should hold true for any `Value`.
-functors(Value) ->
-  [ {ok, Value}
-  , [Value]
-  , #{key => Value}
-  , fun(arg) -> Value end
-  , {Value}].
+%%%_* Functor Laws ------------------------------------------------------------
+%% Add functors to the following list to make sure that their implementation of
+%% `fmap` satisfies the functor laws. Note that if the tests pass this does not
+%% guarantee that the laws hold true, but only that they aren't violated for
+%% the particular test case.
+%% 
+%% The laws should hold true for any value of `A`. We're testing with
+%% `A = {ok, 2}` to ensure that the tests cover the potential conflict
+%% between `list` and `dict` described above.
+functors(A) ->
+  [ [A]
+  , #{key => A}
+  , fun(_) -> A end
+  , {ok, A}
+  , {error, reason}].
 
-assertEqual(Expected, Actual) when is_function(Expected), is_function(Actual) ->
-  assertEqual(Expected(arg), Actual(arg));
-assertEqual(Expected, Actual) ->
-  ?assertEqual(Expected, Actual).
-
+%% Law 1: Mapping the identity function over a functor does not change it
 preserve_identity_morphism_test() ->
   CheckLaw = fun(Functor) -> assertEqual(Functor, fmap(fun s2_funs:id/1, Functor)) end,
   lists:foreach(CheckLaw, functors({ok, 2})).
 
+%% Law 2: If two functions F and G are mapped over a functor sequentially, the
+%% result must be the same as mapping it with a single function that is
+%% equivalent to applying the first function to the result of the second.
 preserve_composition_of_morphisms_test() ->
   F        = fun({ok, Value}) -> {ok, Value - 1}                              end,
   G        = fun({ok, Value}) -> {ok, Value * 2}                              end,
@@ -61,9 +78,22 @@ preserve_composition_of_morphisms_test() ->
   CheckLaw = fun(Functor) -> assertEqual(Chained(Functor), Composed(Functor)) end,
   lists:foreach(CheckLaw, functors({ok, 2})).
 
+%%%_* Other Tests -------------------------------------------------------------
+basic_test() ->
+  F = fun(X) -> X + 1 end,
+  ?assertEqual([2, 3],            fmap(F, [1, 2])),
+  ?assertEqual(#{a => 2, b => 3}, fmap(F, #{a => 1, b => 2})),
+  ?assertEqual(2,                 (fmap(F, fun(_) -> 1 end))(arg)).
+
+%%%_* Test Helpers ------------------------------------------------------------
+assertEqual(Expected, Actual) when is_function(Expected), is_function(Actual) ->
+  assertEqual(Expected(arg), Actual(arg));
+assertEqual(Expected, Actual) ->
+  ?assertEqual(Expected, Actual).
+
 -endif.
 
-%%%_* Emacs ============================================================
+%%%_* Emacs ===================================================================
 %%% Local Variables:
 %%% allout-layout: t
 %%% erlang-indent-level: 2

--- a/src/s2_funs.erl
+++ b/src/s2_funs.erl
@@ -10,6 +10,7 @@
 -export([ fix/2
         , fix/3
         , flip/1
+        , id/1
         , o/1
         , o/2
         , o/3
@@ -54,6 +55,7 @@ flip_test() ->
   [1|0] = (flip(fun s2_lists:cons/2))(0, 1).
 -endif.
 
+id(Arg) -> Arg.
 
 -spec o([fun()]) -> fun().
 %% @doc (o([F, G]))(X) is F(G(X)).

--- a/src/s2_maybe.erl
+++ b/src/s2_maybe.erl
@@ -8,6 +8,7 @@
 
 %%%_* Exports ==========================================================
 -export([ do/1
+        , fmap/2
         , lift/1
         , lift/2
         , map/2
@@ -49,6 +50,19 @@ do_test() ->
        , fun(X) -> {error, X} end
        , Exn
        ]).
+-endif.
+
+-spec fmap(fun((A) -> B), maybe(A, _)) -> maybe(B, _).
+%%@doc fmap(F, Maybe) is the result of mapping F over Maybe.
+fmap(F, {ok, Value})     when is_function(F, 1) -> {ok, F(Value)};
+fmap(F, {error, Reason}) when is_function(F, 1) -> {error, Reason}.
+
+-ifdef(TEST).
+fmap_test() ->
+  {ok, 2}               = fmap(fun(X)  -> X + 1            end, {ok, 1}),
+  {ok, {ok, 2}}         = fmap(fun(X)  -> {ok, X + 1}      end, {ok, 1}),
+  {ok, {error, reason}} = fmap(fun(_X) -> {error, reason}  end, {ok, 1}),
+  {error, reason}       = fmap(fun(_X) -> {error, reason2} end, {error, reason}).
 -endif.
 
 -spec lift(fun()) -> maybe(_, _).

--- a/src/s2_maybe.erl
+++ b/src/s2_maybe.erl
@@ -52,7 +52,7 @@ do_test() ->
        ]).
 -endif.
 
--spec fmap(fun((A) -> B), maybe(A, _)) -> maybe(B, _).
+-spec fmap(fun((A) -> B), maybe(A, C)) -> maybe(B, C).
 %%@doc fmap(F, Maybe) is the result of mapping F over Maybe.
 fmap(F, {ok, Value})     when is_function(F, 1) -> {ok, F(Value)};
 fmap(F, {error, Reason}) when is_function(F, 1) -> {error, Reason}.
@@ -61,6 +61,7 @@ fmap(F, {error, Reason}) when is_function(F, 1) -> {error, Reason}.
 fmap_test() ->
   {ok, 2}               = fmap(fun(X)  -> X + 1            end, {ok, 1}),
   {ok, {ok, 2}}         = fmap(fun(X)  -> {ok, X + 1}      end, {ok, 1}),
+  {error, reason}       = fmap(fun(X)  -> X + 1            end, {error, reason}),
   {ok, {error, reason}} = fmap(fun(_X) -> {error, reason}  end, {ok, 1}),
   {error, reason}       = fmap(fun(_X) -> {error, reason2} end, {error, reason}).
 -endif.


### PR DESCRIPTION
## About
A bit of an after-hour fun project 🙂: I was missing an easy (and readable) way to map a function over a `maybe`. Currently one would need to write something like this:

```erlang
Maybe = {ok, 5},
?do(?thunk(Maybe)
  , fun(Num) -> Num + 1 end),
```

With my proposed changes one could write:

```erlang
Maybe = {ok, 5},
?fmap(fun(Num) -> Num + 1 end, Maybe),
```

, which I think is much clearer and more readable.

While I was at it, I added a Haskell-inspired functor type class(-ish) implementation of `fmap`, so one can also `fmap` over lists, maps, and functions. Not sure if that's controversial in Erlang.