### PR TITLE
chore: Allow separate import of maybe monad macros

### DIFF
--- a/include/maybe.hrl
+++ b/include/maybe.hrl
@@ -1,0 +1,100 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% @doc Maybe Monads
+%%% @end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%_* Types ============================================================
+-type functor(A)  :: s2_functors:functor(A).
+-type thunk(A)    :: fun(() -> A).
+
+-type ok(A)       :: {ok, A}.
+-type error(A)    :: {error, A}.
+-type maybe(A, B) :: ok(A) | error(B).
+-type whynot(A)   :: ok | error(A).
+
+%%%_* Macros ===========================================================
+-define(lift(E),   s2_maybe:lift(fun() -> E end)).
+-define(unlift(E), s2_maybe:unlift(fun() -> E end)).
+
+-define(do(F0, F1),
+        s2_maybe:do([F0, F1])).
+-define(do(F0, F1, F2),
+        s2_maybe:do([F0, F1, F2])).
+-define(do(F0, F1, F2, F3),
+        s2_maybe:do([F0, F1, F2, F3])).
+-define(do(F0, F1, F2, F3, F4),
+        s2_maybe:do([F0, F1, F2, F3, F4])).
+-define(do(F0, F1, F2, F3, F4, F5),
+        s2_maybe:do([F0, F1, F2, F3, F4, F5])).
+-define(do(F0, F1, F2, F3, F4, F5, F6),
+        s2_maybe:do([F0, F1, F2, F3, F4, F5, F6])).
+-define(do(F0, F1, F2, F3, F4, F5, F6, F7),
+        s2_maybe:do([F0, F1, F2, F3, F4, F5, F6, F7])).
+-define(do(F0, F1, F2, F3, F4, F5, F6, F7, F8),
+        s2_maybe:do([F0, F1, F2, F3, F4, F5, F6, F7, F8])).
+-define(do(F0, F1, F2, F3, F4, F5, F6, F7, F8, F9),
+        s2_maybe:do([F0, F1, F2, F3, F4, F5, F6, F7, F8, F9])).
+
+-define(fmap(F, Functor),
+        s2_functors:fmap(F, Functor)).
+
+-define(ido(F0, F1),
+        ?ido([F0, F1])).
+-define(ido(F0, F1, F2),
+        ?ido([F0, F1, F2])).
+-define(ido(F0, F1, F2, F3),
+        ?ido([F0, F1, F2, F3])).
+-define(ido(F0, F1, F2, F3, F4),
+        ?ido([F0, F1, F2, F3, F4])).
+-define(ido(F0, F1, F2, F3, F4, F5),
+        ?ido([F0, F1, F2, F3, F4, F5])).
+-define(ido(F0, F1, F2, F3, F4, F5, F6),
+        ?ido([F0, F1, F2, F3, F4, F5, F6])).
+-define(ido(F0, F1, F2, F3, F4, F5, F6, F7),
+        ?ido([F0, F1, F2, F3, F4, F5, F6, F7])).
+-define(ido(F0, F1, F2, F3, F4, F5, F6, F7, F8),
+        ?ido([F0, F1, F2, F3, F4, F5, F6, F7, F8])).
+-define(ido(F0, F1, F2, F3, F4, F5, F6, F7, F8, F9),
+        ?ido([F0, F1, F2, F3, F4, F5, F6, F7, F8, F9])).
+
+%% Instrumented do.
+-define(ido(Fs),
+        (case ?TIME(?FUNCTION, s2_maybe:do(Fs)) of
+           {ok, ___Res} = ___Ok ->
+             ?debug("~p: ok: ~p", [?FUNCTION, ___Res]),
+             ?increment(?FUNCTION, ok),
+             ___Ok;
+           {error, ___Rsn} = ___Err ->
+             ?error("~p: error: ~p", [?FUNCTION, ___Rsn]),
+             ?increment(?FUNCTION, error),
+             ___Err
+         end)).
+
+-define(thunk(E0),
+        fun() -> E0 end).
+-define(thunk(E0, E1),
+        fun() -> E0, E1 end).
+-define(thunk(E0, E1, E2),
+        fun() -> E0, E1, E2 end).
+-define(thunk(E0, E1, E2, E3),
+        fun() -> E0, E1, E2, E3 end).
+-define(thunk(E0, E1, E2, E3, E4),
+        fun() -> E0, E1, E2, E3, E4 end).
+-define(thunk(E0, E1, E2, E3, E4, E5),
+        fun() -> E0, E1, E2, E3, E4, E5 end).
+-define(thunk(E0, E1, E2, E3, E4, E5, E6),
+        fun() -> E0, E1, E2, E3, E4, E5, E6 end).
+-define(thunk(E0, E1, E2, E3, E4, E5, E6, E7),
+        fun() -> E0, E1, E2, E3, E4, E5, E6, E7 end).
+-define(thunk(E0, E1, E2, E3, E4, E5, E6, E7, E8),
+        fun() -> E0, E1, E2, E3, E4, E5, E6, E7, E8 end).
+-define(thunk(E0, E1, E2, E3, E4, E5, E6, E7, E8, E9),
+        fun() -> E0, E1, E2, E3, E4, E5, E6, E7, E8, E9 end).
+
+%%%_* Guards ===========================================================
+-define(is_thunk(X), is_function(X, 0)).
+
+%%% Local Variables:
+%%% allout-layout: t
+%%% erlang-indent-level: 2
+%%% End:

--- a/include/prelude.hrl
+++ b/include/prelude.hrl
@@ -12,6 +12,8 @@
 -include_lib("kernel/include/logger.hrl").
 -endif.
 
+-include("maybe.hrl").
+
 %%%_* Assertions =======================================================
 -define(hence(A), ?assert(A)).
 
@@ -37,85 +39,6 @@
 -define(l2t(X), erlang:list_to_tuple(X)).
 -define(t2l(X), erlang:tuple_to_list(X)).
 
-%%%_* Eccentric ========================================================
--define(lift(E),   s2_maybe:lift(fun() -> E end)).
--define(unlift(E), s2_maybe:unlift(fun() -> E end)).
-
--define(do(F0, F1),
-        s2_maybe:do([F0, F1])).
--define(do(F0, F1, F2),
-        s2_maybe:do([F0, F1, F2])).
--define(do(F0, F1, F2, F3),
-        s2_maybe:do([F0, F1, F2, F3])).
--define(do(F0, F1, F2, F3, F4),
-        s2_maybe:do([F0, F1, F2, F3, F4])).
--define(do(F0, F1, F2, F3, F4, F5),
-        s2_maybe:do([F0, F1, F2, F3, F4, F5])).
--define(do(F0, F1, F2, F3, F4, F5, F6),
-        s2_maybe:do([F0, F1, F2, F3, F4, F5, F6])).
--define(do(F0, F1, F2, F3, F4, F5, F6, F7),
-        s2_maybe:do([F0, F1, F2, F3, F4, F5, F6, F7])).
--define(do(F0, F1, F2, F3, F4, F5, F6, F7, F8),
-        s2_maybe:do([F0, F1, F2, F3, F4, F5, F6, F7, F8])).
--define(do(F0, F1, F2, F3, F4, F5, F6, F7, F8, F9),
-        s2_maybe:do([F0, F1, F2, F3, F4, F5, F6, F7, F8, F9])).
-
--define(fmap(F, Functor),
-        s2_functors:fmap(F, Functor)).
-
--define(ido(F0, F1),
-        ?ido([F0, F1])).
--define(ido(F0, F1, F2),
-        ?ido([F0, F1, F2])).
--define(ido(F0, F1, F2, F3),
-        ?ido([F0, F1, F2, F3])).
--define(ido(F0, F1, F2, F3, F4),
-        ?ido([F0, F1, F2, F3, F4])).
--define(ido(F0, F1, F2, F3, F4, F5),
-        ?ido([F0, F1, F2, F3, F4, F5])).
--define(ido(F0, F1, F2, F3, F4, F5, F6),
-        ?ido([F0, F1, F2, F3, F4, F5, F6])).
--define(ido(F0, F1, F2, F3, F4, F5, F6, F7),
-        ?ido([F0, F1, F2, F3, F4, F5, F6, F7])).
--define(ido(F0, F1, F2, F3, F4, F5, F6, F7, F8),
-        ?ido([F0, F1, F2, F3, F4, F5, F6, F7, F8])).
--define(ido(F0, F1, F2, F3, F4, F5, F6, F7, F8, F9),
-        ?ido([F0, F1, F2, F3, F4, F5, F6, F7, F8, F9])).
-
-%% Instrumented do.
--define(ido(Fs),
-        (case ?TIME(?FUNCTION, s2_maybe:do(Fs)) of
-           {ok, ___Res} = ___Ok ->
-             ?debug("~p: ok: ~p", [?FUNCTION, ___Res]),
-             ?increment(?FUNCTION, ok),
-             ___Ok;
-           {error, ___Rsn} = ___Err ->
-             ?error("~p: error: ~p", [?FUNCTION, ___Rsn]),
-             ?increment(?FUNCTION, error),
-             ___Err
-         end)).
-
--define(thunk(E0),
-        fun() -> E0 end).
--define(thunk(E0, E1),
-        fun() -> E0, E1 end).
--define(thunk(E0, E1, E2),
-        fun() -> E0, E1, E2 end).
--define(thunk(E0, E1, E2, E3),
-        fun() -> E0, E1, E2, E3 end).
--define(thunk(E0, E1, E2, E3, E4),
-        fun() -> E0, E1, E2, E3, E4 end).
--define(thunk(E0, E1, E2, E3, E4, E5),
-        fun() -> E0, E1, E2, E3, E4, E5 end).
--define(thunk(E0, E1, E2, E3, E4, E5, E6),
-        fun() -> E0, E1, E2, E3, E4, E5, E6 end).
--define(thunk(E0, E1, E2, E3, E4, E5, E6, E7),
-        fun() -> E0, E1, E2, E3, E4, E5, E6, E7 end).
--define(thunk(E0, E1, E2, E3, E4, E5, E6, E7, E8),
-        fun() -> E0, E1, E2, E3, E4, E5, E6, E7, E8 end).
--define(thunk(E0, E1, E2, E3, E4, E5, E6, E7, E8, E9),
-        fun() -> E0, E1, E2, E3, E4, E5, E6, E7, E8, E9 end).
-
 %%%_* Emacs ============================================================
 -define(Q,  $\'). %'
 -define(QQ, $\"). %"
@@ -123,8 +46,6 @@
 %%%_* Guards ===========================================================
 -define(is_string(X),
         (((X) =:= "") orelse (is_list(X) andalso is_integer(hd(X))))).
-
--define(is_thunk(X), is_function(X, 0)).
 
 %%%_* Logging ==========================================================
 -ifdef(S2_USE_OTP_LOGGER).
@@ -485,13 +406,6 @@
 -type alist(A, B) :: [{A, B}].
 -type fd()        :: file:io_device().
 -type file()      :: string().
--type functor(A)  :: s2_functors:functor(A).
--type thunk(A)    :: fun(() -> A).
-
--type ok(A)       :: {ok, A}.
--type error(A)    :: {error, A}.
--type maybe(A, B) :: {ok, A} | {error, B}.
--type whynot(B)   :: ok | {error, B}.
 
 %%%_* Footer ===========================================================
 -endif. %include guard


### PR DESCRIPTION
## About

Importing the `prelude` header file can lead to namespace issues in some projects. I think it would be good to break it up into smaller header files that can be imported individually if needed. For now I'm creating a separate file with `maybe`-related things. We could do the same for all things related to logging.