### PR TITLE
feat: Add 'sequence' and 'liftm' for maybe monads

### DIFF
--- a/include/maybe.hrl
+++ b/include/maybe.hrl
@@ -4,8 +4,9 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%%_* Types ============================================================
--type functor(A)  :: s2_functors:functor(A).
--type thunk(A)    :: fun(() -> A).
+-type functor(A)    :: s2_functors:functor(A).
+-type thunk(A)      :: fun(() -> A).
+-type collection(A) :: [A] | #{_ := A}.
 
 -type ok(A)       :: {ok, A}.
 -type error(A)    :: {error, A}.

--- a/include/maybe.hrl
+++ b/include/maybe.hrl
@@ -70,24 +70,7 @@
              ___Err
          end)).
 
--define(liftM(F, A1),
-        s2_maybe:liftM(F, [A1])).
--define(liftM(F, A1, A2),
-        s2_maybe:liftM(F, [A1, A2])).
--define(liftM(F, A1, A2, A3),
-        s2_maybe:liftM(F, [A1, A2, A3])).
--define(liftM(F, A1, A2, A3, A4),
-        s2_maybe:liftM(F, [A1, A2, A3, A4])).
--define(liftM(F, A1, A2, A3, A4, A5),
-        s2_maybe:liftM(F, [A1, A2, A3, A4, A5])).
--define(liftM(F, A1, A2, A3, A4, A5, A6),
-        s2_maybe:liftM(F, [A1, A2, A3, A4, A5, A6])).
--define(liftM(F, A1, A2, A3, A4, A5, A6, A7),
-        s2_maybe:liftM(F, [A1, A2, A3, A4, A5, A6, A7])).
--define(liftM(F, A1, A2, A3, A4, A5, A6, A7, A8),
-        s2_maybe:liftM(F, [A1, A2, A3, A4, A5, A6, A7, A8])).
--define(liftM(F, A1, A2, A3, A4, A5, A6, A7, A8, A9),
-        s2_maybe:liftM(F, [A1, A2, A3, A4, A5, A6, A7, A8, A9])).
+-define(liftm(F, Args), s2_maybe:liftm(F, Args)).
 
 -define(thunk(E0),
         fun() -> E0 end).

--- a/include/maybe.hrl
+++ b/include/maybe.hrl
@@ -70,8 +70,6 @@
              ___Err
          end)).
 
--define(liftm(F, Args), s2_maybe:liftm(F, Args)).
-
 -define(thunk(E0),
         fun() -> E0 end).
 -define(thunk(E0, E1),
@@ -92,6 +90,31 @@
         fun() -> E0, E1, E2, E3, E4, E5, E6, E7, E8 end).
 -define(thunk(E0, E1, E2, E3, E4, E5, E6, E7, E8, E9),
         fun() -> E0, E1, E2, E3, E4, E5, E6, E7, E8, E9 end).
+
+-define(liftm(F, A1),
+        s2_maybe:liftm(F, [?thunk(A1)])).
+-define(liftm(F, A1, A2),
+        s2_maybe:liftm(F, [?thunk(A1), ?thunk(A2)])).
+-define(liftm(F, A1, A2, A3),
+        s2_maybe:liftm(F, [?thunk(A1), ?thunk(A2), ?thunk(A3)])).
+-define(liftm(F, A1, A2, A3, A4),
+        s2_maybe:liftm(F, [?thunk(A1), ?thunk(A2), ?thunk(A3), ?thunk(A4)])).
+-define(liftm(F, A1, A2, A3, A4, A5),
+        s2_maybe:liftm(F, [?thunk(A1), ?thunk(A2), ?thunk(A3), ?thunk(A4),
+                           ?thunk(A5)])).
+-define(liftm(F, A1, A2, A3, A4, A5, A6),
+        s2_maybe:liftm(F, [?thunk(A1), ?thunk(A2), ?thunk(A3), ?thunk(A4),
+                           ?thunk(A5), ?thunk(A6)])).
+-define(liftm(F, A1, A2, A3, A4, A5, A6, A7),
+        s2_maybe:liftm(F, [?thunk(A1), ?thunk(A2), ?thunk(A3), ?thunk(A4),
+                           ?thunk(A5), ?thunk(A6), ?thunk(A7)])).
+-define(liftm(F, A1, A2, A3, A4, A5, A6, A7, A8),
+        s2_maybe:liftm(F, [?thunk(A1), ?thunk(A2), ?thunk(A3), ?thunk(A4),
+                           ?thunk(A5), ?thunk(A6), ?thunk(A7), ?thunk(A8)])).
+-define(liftm(F, A1, A2, A3, A4, A5, A6, A7, A8, A9),
+        s2_maybe:liftm(F, [?thunk(A1), ?thunk(A2), ?thunk(A3), ?thunk(A4),
+                           ?thunk(A5), ?thunk(A6), ?thunk(A7), ?thunk(A8),
+                           ?thunk(A9)])).
 
 %%%_* Guards ===========================================================
 -define(is_thunk(X), is_function(X, 0)).

--- a/include/maybe.hrl
+++ b/include/maybe.hrl
@@ -70,6 +70,25 @@
              ___Err
          end)).
 
+-define(liftM(F, A1),
+        s2_maybe:liftM(F, [A1])).
+-define(liftM(F, A1, A2),
+        s2_maybe:liftM(F, [A1, A2])).
+-define(liftM(F, A1, A2, A3),
+        s2_maybe:liftM(F, [A1, A2, A3])).
+-define(liftM(F, A1, A2, A3, A4),
+        s2_maybe:liftM(F, [A1, A2, A3, A4])).
+-define(liftM(F, A1, A2, A3, A4, A5),
+        s2_maybe:liftM(F, [A1, A2, A3, A4, A5])).
+-define(liftM(F, A1, A2, A3, A4, A5, A6),
+        s2_maybe:liftM(F, [A1, A2, A3, A4, A5, A6])).
+-define(liftM(F, A1, A2, A3, A4, A5, A6, A7),
+        s2_maybe:liftM(F, [A1, A2, A3, A4, A5, A6, A7])).
+-define(liftM(F, A1, A2, A3, A4, A5, A6, A7, A8),
+        s2_maybe:liftM(F, [A1, A2, A3, A4, A5, A6, A7, A8])).
+-define(liftM(F, A1, A2, A3, A4, A5, A6, A7, A8, A9),
+        s2_maybe:liftM(F, [A1, A2, A3, A4, A5, A6, A7, A8, A9])).
+
 -define(thunk(E0),
         fun() -> E0 end).
 -define(thunk(E0, E1),

--- a/src/s2_lists.erl
+++ b/src/s2_lists.erl
@@ -15,7 +15,6 @@
         , dissoc/2
         , drop/2
         , dsort/1
-        , foldl_while/3
         , intersperse/2
         , is_permutation/2
         , partition/2
@@ -105,20 +104,6 @@ drop_test() ->
   []    = drop(2, []).
 -endif.
 
-foldl_while(F, Acc, [Elm | Tail]) when is_function(F, 2) ->
-  case F(Elm, Acc) of
-    {ok, Acc1}   -> foldl_while(F, Acc1, Tail);
-    {stop, Acc1} -> Acc1
-  end;
-foldl_while(_F, Acc, []) -> Acc.
-
--ifdef(TEST).
-foldl_while_test() ->
-  ?assertEqual(10, foldl_while(fun(N, Acc) when Acc < 7  -> {ok, N + Acc};
-                                  (_N, Acc)              -> {stop, Acc} end,
-                               0, [1, 2, 3, 4, 5, 6, 7, 8, 9])).
-
--endif.
 
 -spec intersperse(_, [_]) -> [_].
 %% @doc intersperse(X, Ys) is Ys with X interspersed.

--- a/src/s2_lists.erl
+++ b/src/s2_lists.erl
@@ -15,6 +15,7 @@
         , dissoc/2
         , drop/2
         , dsort/1
+        , foldl_while/3
         , intersperse/2
         , is_permutation/2
         , partition/2
@@ -104,6 +105,12 @@ drop_test() ->
   []    = drop(2, []).
 -endif.
 
+foldl_while(F, Acc, [Elm | Tail]) when is_function(F, 2) ->
+  case F(Elm, Acc) of
+    {ok, Acc1}   -> foldl_while(F, Acc1, Tail);
+    {stop, Acc1} -> Acc1
+  end;
+foldl_while(_F, Acc, []) -> Acc.
 
 -spec intersperse(_, [_]) -> [_].
 %% @doc intersperse(X, Ys) is Ys with X interspersed.

--- a/src/s2_lists.erl
+++ b/src/s2_lists.erl
@@ -112,6 +112,14 @@ foldl_while(F, Acc, [Elm | Tail]) when is_function(F, 2) ->
   end;
 foldl_while(_F, Acc, []) -> Acc.
 
+-ifdef(TEST).
+foldl_while_test() ->
+  ?assertEqual(10, foldl_while(fun(N, Acc) when Acc < 7  -> {ok, N + Acc};
+                                  (_N, Acc)              -> {stop, Acc} end,
+                               0, [1, 2, 3, 4, 5, 6, 7, 8, 9])).
+
+-endif.
+
 -spec intersperse(_, [_]) -> [_].
 %% @doc intersperse(X, Ys) is Ys with X interspersed.
 intersperse(X, Ys) ->

--- a/src/s2_maybe.erl
+++ b/src/s2_maybe.erl
@@ -11,7 +11,7 @@
         , fmap/2
         , lift/1
         , lift/2
-        , liftM/2
+        , liftm/2
         , map/2
         , reduce/2
         , reduce/3
@@ -110,9 +110,9 @@ lift_unlift_test() ->
   42             = unlift(fun(X) -> {ok, X} end, 42).
 -endif.
 
--spec liftM(fun(), [maybe(_, B)]) -> maybe(_, B).
+-spec liftm(fun(), [maybe(_, B)]) -> maybe(_, B).
 %% @doc lift a function F into the Maybe monad.
-liftM(F, Maybes) when is_list(Maybes) and is_function(F, length(Maybes)) ->
+liftm(F, Maybes) when is_list(Maybes) and is_function(F, length(Maybes)) ->
   ?fmap(fun(Args) -> apply(F, Args) end, sequence(Maybes)).
 
 -ifdef(TEST).
@@ -120,9 +120,9 @@ liftM_test() ->
   Add3      = fun(A, B, C) -> A + B + C end,
   ValsOK    = [{ok, 1}, {ok, 2},         {ok, 3}], 
   ValsError = [{ok, 1}, {error, reason}, {ok, 3}],
-  ?assertEqual({ok, 6},         liftM(Add3, ValsOK)),
-  ?assertEqual({error, reason}, liftM(Add3, ValsError)),
-  ?assertEqual({ok, 6},         ?liftM(Add3, {ok, 1}, {ok, 2}, {ok, 3})).
+  ?assertEqual({ok, 6},         liftm(Add3, ValsOK)),
+  ?assertEqual({error, reason}, liftm(Add3, ValsError)),
+  ?assertEqual({ok, 6},         ?liftm(Add3, [{ok, 1}, {ok, 2}, {ok, 3}])).
 -endif.
 
 -spec map(fun(), [_]) -> maybe(_, _).
@@ -136,7 +136,6 @@ map_test() ->
   {ok, [1, 2]} = map(fun(X) -> {ok, X + 1} end, [0, 1]),
   {error, _}   = map(fun(X) -> X + 1       end, [0, foo]).
 -endif.
-
 
 -spec reduce(fun(), [_]) -> maybe(_, _).
 %% @doc reduce(F, Xs) is the result of reducing Xs to F inside the maybe
@@ -154,6 +153,8 @@ reduce_test() ->
 -endif.
 
 -spec sequence([maybe(A, B)]) -> maybe([A], B).
+%% @doc sequence(Maybes) evaluates each maybe in a list of maybes and collects
+%% the results inside the maybe monad.
 sequence(Maybes) when is_list(Maybes) ->
   ?fmap(fun lists:reverse/1,
         ?lift(s2_lists:foldl_while(fun({ok, Val}, Acc)  -> {ok, [Val | Acc]};


### PR DESCRIPTION
## About

This PR adds the functions [`sequence`](https://hackage.haskell.org/package/base-4.15.0.0/docs/Data-Traversable.html#v:sequence) and [`liftm`](https://wiki.haskell.org/Lifting#Monad_lifting) for maybe monads, as well as a `?liftm` macro.

The `sequence` function sequences all maybes inside a collection (list or map):

```erlang
ListOfMaybes    = [{ok, 1}, {ok, 2}, {ok, 3}],
{ok, [1, 2, 3]} = sequence(ListOfMaybes),

MapOfMaybes             = #{a => {ok, 1}, b => {ok, 2}},
{ok, #{a := 1, b := 2}} = sequence(MapOfMaybes)
```

The `liftm` function/macro lifts a function so that it can operate on maybe monads:
```erlang
Add3    = fun(A, B, C) -> A + B + C end,
{ok, 6} = liftm(Add3, [{ok, 1}, {ok, 2}, {ok, 3}]), % takes list of maybes
{ok, 6} = ?liftm(Add3, {ok, 1}, {ok, 2}, {ok, 3}).  % takes maybes directly
```

Both `sequence` and `liftm` support lazy evaluation of thunks:
```erlang
{error, Reason} = sequence([?thunk(this_will_return_an_error()),
                            ?thunk(this_will_never_run())]).
```

The `?liftm` macro wraps all arguments in thunks automatically:

```erlang
{error, Reason} = ?liftm(Add3, this_will_return_an_error(),
                               this_will_never_run(),
                               this_will_never_run()).
```