### PR TITLE
fix: Logger macro errors

### DIFF
--- a/include/prelude.hrl
+++ b/include/prelude.hrl
@@ -141,7 +141,7 @@
   -else.
     -ifdef(S2_DEBUG).
       -define(debug(Msg),            ?debug(Msg, [])).
-      -define(debug(Fmt, As),        ?do_debug("~p:~s:~p: Debug: " Fmt "~n",
+      -define(debug(Fmt, As),        ?do_debug(unicode:characters_to_list(["~p:~s:~p: Debug: ", Fmt, "~n"]),
                                               [self(), ?FILE, ?LINE|As])).
     -else.
       -define(debug(Msg),            ok).
@@ -149,25 +149,25 @@
     -endif. %S2_DEBUG
 
     -define(info(Msg),             ?info(Msg, [])).
-    -define(info(Fmt, As),         ?do_info("~p:~s:~p: Info: " Fmt "~n",
+    -define(info(Fmt, As),         ?do_info(unicode:characters_to_list(["~p:~s:~p: Info: ", Fmt, "~n"]),
                                             [self(), ?FILE, ?LINE|As])).
     -define(notice(Msg),           ?notice(Msg, [])).
-    -define(notice(Fmt, As),       ?do_notice("~p:~s:~p: Notice: " Fmt "~n",
+    -define(notice(Fmt, As),       ?do_notice(unicode:characters_to_list(["~p:~s:~p: Notice: ", Fmt, "~n"]),
                                               [self(), ?FILE, ?LINE|As])).
     -define(warning(Msg),          ?warning(Msg, [])).
-    -define(warning(Fmt, As),      ?do_warning("~p:~s:~p: Warning: " Fmt "~n",
+    -define(warning(Fmt, As),      ?do_warning(unicode:characters_to_list(["~p:~s:~p: Warning: ", Fmt, "~n"]),
                                               [self(), ?FILE, ?LINE|As])).
     -define(error(Msg),            ?error(Msg, [])).
-    -define(error(Fmt, As),        ?do_error("~p:~s:~p: Error: " Fmt "~n",
+    -define(error(Fmt, As),        ?do_error(unicode:characters_to_list(["~p:~s:~p: Error: ", Fmt, "~n"]),
                                             [self(), ?FILE, ?LINE|As])).
     -define(critical(Msg),         ?critical(Msg, [])).
-    -define(critical(Fmt, As),     ?do_critical("~p:~s:~p: Critical: " Fmt "~n",
+    -define(critical(Fmt, As),     ?do_critical(unicode:characters_to_list(["~p:~s:~p: Critical: ", Fmt, "~n"]),
                                                 [self(), ?FILE, ?LINE|As])).
     -define(alert(Msg),            ?alert(Msg, [])).
-    -define(alert(Fmt, As),        ?do_alert("~p:~s:~p: Alert: " Fmt "~n",
+    -define(alert(Fmt, As),        ?do_alert(unicode:characters_to_list(["~p:~s:~p: Alert: ", Fmt, "~n"]),
                                             [self(), ?FILE, ?LINE|As])).
     -define(emergency(Msg),        ?emergency(Msg, [])).
-    -define(emergency(Fmt, As),    ?do_emergency("~p:~s:~p: Emergency: " Fmt "~n",
+    -define(emergency(Fmt, As),    ?do_emergency(unicode:characters_to_list(["~p:~s:~p: Emergency: ", Fmt, "~n"]),
                                                 [self(), ?FILE, ?LINE|As])).
 
     -ifdef(S2_NOLOG).


### PR DESCRIPTION
## About

For some legacy logger macros, we generate format strings by inserting `Fmt` into a format string. For example:

```erlang
-define(debug(Fmt, As), ?do_debug("~p:~s:~p: Debug: " Fmt "~n", ...)
```

This works fine if the macro is then used like this:

```erlang
?debug("My Message"),
```

However, this will result in a syntax error if used like this:

```erlang
Message = "My Message",
?debug(MyMessage),
```